### PR TITLE
Add check if chsh is installed

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,13 @@ else
     INSTALL=$INSTALL" curl"
 fi
 
+# Check if chsh is installed
+if [ $(which chsh) ]; then
+    echo "chsh already installed"
+else
+    INSTALL=$INSTALL" util-linux-user"
+fi
+
 if [ ! -z $INSTALL ]; then
     if [ $(which apt-get) ]; then
         $SUDO apt-get install $INSTALL


### PR DESCRIPTION
This PR adds a check whether the command chsh is installed and otherwise install the util-linux-user package, which includes chsh. This is necessary as e.g. Amazon Linux 2 does not come with chsh preinstalled.